### PR TITLE
[Feat] #8 - Cloud Run DB Secret 구성

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,6 @@ out
 HELP.md
 docker-compose.yml
 gha-creds-*.json
-src/main/resources/application.yml
-src/main/resources/application-*.yml
+src/main/resources/application-local.yml
+src/main/resources/application-prod.yml
 src/main/resources/firebase/*.json

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -17,9 +17,9 @@ concurrency:
 env:
   GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
   GCP_REGION: ${{ vars.GCP_REGION || 'asia-northeast3' }}
-  CLOUD_RUN_SERVICE: ${{ vars.CLOUD_RUN_SERVICE || 'aim-backend' }}
-  ARTIFACT_REGISTRY_REPOSITORY: ${{ vars.ARTIFACT_REGISTRY_REPOSITORY || 'aim' }}
-  IMAGE_NAME: ${{ vars.IMAGE_NAME || 'aim-backend' }}
+  CLOUD_RUN_SERVICE: ${{ vars.CLOUD_RUN_SERVICE || 'aim-be' }}
+  ARTIFACT_REGISTRY_REPOSITORY: ${{ vars.ARTIFACT_REGISTRY_REPOSITORY || 'app-repo' }}
+  IMAGE_NAME: ${{ vars.IMAGE_NAME || 'aim-be' }}
   GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
   GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,8 @@ out/
 .vscode/
 
 src/main/resources/firebase/ajou-project-cafd9-firebase-adminsdk-fbsvc-e6d8a32d57.json
-src/main/resources/application.yml
 src/main/resources/application-prod.yml
+src/main/resources/application-local.yml
 
 docker-compose.yml
 

--- a/docs/cicd-cloud-run.md
+++ b/docs/cicd-cloud-run.md
@@ -57,9 +57,9 @@ Repository Settings > Secrets and variables > Actions > Variables에 등록한�
 | --- | --- | --- |
 | `GCP_PROJECT_ID` | `my-project` | Google Cloud project ID |
 | `GCP_REGION` | `asia-northeast3` | Cloud Run 및 Artifact Registry region |
-| `CLOUD_RUN_SERVICE` | `aim-backend` | Cloud Run service name |
-| `ARTIFACT_REGISTRY_REPOSITORY` | `aim` | Artifact Registry repository ID |
-| `IMAGE_NAME` | `aim-backend` | Docker image name |
+| `CLOUD_RUN_SERVICE` | `aim-be` | Cloud Run service name |
+| `ARTIFACT_REGISTRY_REPOSITORY` | `app-repo` | Artifact Registry repository ID |
+| `IMAGE_NAME` | `aim-be` | Docker image name |
 | `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/123456789/locations/global/workloadIdentityPools/aim-backend-github/providers/github` | Terraform output `github_workload_identity_provider` |
 | `GCP_SERVICE_ACCOUNT` | `github-actions-deployer@my-project.iam.gserviceaccount.com` | Terraform output `deployer_service_account_email` |
 
@@ -81,6 +81,7 @@ Terraform은 앱 배포 실행 도구가 아니다. 다음 GCP 기준 상태를 
 - GitHub Actions impersonation IAM
 - IAM
 - Secret Manager
+- DB password secret env 연결
 - Cloud Run secret mount/env 연결
 
 Cloud Run image revision은 GitHub Actions가 관리한다. Terraform은 `template[0].containers[0].image` drift를 되돌리지 않도록 구성되어 있다.
@@ -97,6 +98,17 @@ Cloud Run runtime 계약:
 
 로컬 개발에서는 기존 classpath JSON fallback도 유지된다.
 
+## Database Credential
+
+DB는 Oracle Cloud에 올라간 MySQL을 사용한다. 애플리케이션 이미지는 비밀번호 없이 다음 환경변수 계약으로 실행된다.
+
+- `DB_URL=jdbc:mysql://161.33.46.41:3306/aim?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8`
+- `DB_USER=aim_be`
+- `DB_PASSWORD=<Secret Manager latest version>`
+- `DDL_AUTO=update`
+
+DB 비밀번호는 저장소와 Terraform 변수 파일에 넣지 않고 Secret Manager secret version으로만 등록한다.
+
 ## 최초 설정 순서
 
 1. Terraform 변수 값을 준비한다.
@@ -104,12 +116,13 @@ Cloud Run runtime 계약:
 3. `terraform init`, `terraform fmt -check`, `terraform validate`, `terraform plan`을 실행한다.
 4. 의도한 변경만 있는지 확인한 뒤 `terraform apply`를 실행한다.
 5. Firebase Admin SDK JSON을 Secret Manager secret version으로 등록한다.
-6. Terraform output `github_workload_identity_provider`를 GitHub Variable `GCP_WORKLOAD_IDENTITY_PROVIDER`에 등록한다.
-7. Terraform output `deployer_service_account_email`을 GitHub Variable `GCP_SERVICE_ACCOUNT`에 등록한다.
-8. 나머지 GitHub Variables를 등록한다.
-9. 기존 `GCP_SA_KEY` secret을 쓰고 있었다면 새 workflow 배포 성공 후 폐기한다.
-10. `feature/*` 브랜치에서 `main`으로 PR을 열어 CI check를 확인한다.
-11. `main` merge 후 Cloud Run 배포 workflow를 확인한다.
+6. DB password를 Secret Manager secret version으로 등록한다.
+7. Terraform output `github_workload_identity_provider`를 GitHub Variable `GCP_WORKLOAD_IDENTITY_PROVIDER`에 등록한다.
+8. Terraform output `deployer_service_account_email`을 GitHub Variable `GCP_SERVICE_ACCOUNT`에 등록한다.
+9. 나머지 GitHub Variables를 등록한다.
+10. 기존 `GCP_SA_KEY` secret을 쓰고 있었다면 새 workflow 배포 성공 후 폐기한다.
+11. `feature/*` 브랜치에서 `main`으로 PR을 열어 CI check를 확인한다.
+12. `main` merge 후 Cloud Run 배포 workflow를 확인한다.
 
 ## 실패 대응
 
@@ -118,4 +131,5 @@ Cloud Run runtime 계약:
 - GCP 인증 실패: `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`, Terraform WIF provider의 repository/ref 조건을 확인한다.
 - Docker push 실패: Artifact Registry repository 이름, region, service account 권한을 확인한다.
 - Cloud Run deploy 실패: deployer service account의 `roles/run.admin`, runtime service account에 대한 `roles/iam.serviceAccountUser`, Artifact Registry reader 권한을 확인한다.
+- DB 연결 실패: `DB_PASSWORD` secret version 존재 여부, Cloud Run runtime service account의 secret accessor 권한, `DB_URL`/`DB_USER` 값을 확인한다.
 - Firebase 초기화 실패: Secret Manager secret version 존재 여부, runtime service account의 secret accessor 권한, `FIREBASE_CREDENTIALS_PATH` mount를 확인한다.

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -10,6 +10,7 @@
 - GitHub OIDC Workload Identity Pool/Provider
 - Cloud Run v2 서비스 baseline
 - Firebase Admin SDK credential용 Secret Manager secret
+- DB password용 Secret Manager secret
 - Artifact Registry, Cloud Run, Secret Manager IAM
 
 ## 이미지 소유권
@@ -56,6 +57,23 @@ Cloud Run에는 다음 계약으로 mount된다.
 - mount path: `/secrets/firebase-adminsdk.json`
 - env: `FIREBASE_CREDENTIALS_PATH=/secrets/firebase-adminsdk.json`
 - env: `FIREBASE_STORAGE_BUCKET=<bucket>`
+
+## DB Password Secret
+
+DB 비밀번호는 저장소, `terraform.tfvars`, Terraform state에 넣지 않는다. Terraform은 secret container와 Cloud Run env 연결만 관리하고, 실제 secret version은 별도 명령으로 등록한다.
+
+```bash
+printf '%s' '<DB_PASSWORD>' | gcloud secrets versions add "$(terraform output -raw db_password_secret_id)" \
+  --data-file=- \
+  --project "<PROJECT_ID>"
+```
+
+Cloud Run에는 다음 계약으로 주입된다.
+
+- env: `DB_URL=<JDBC URL>`
+- env: `DB_USER=aim_be`
+- env: `DB_PASSWORD=<Secret Manager latest version>`
+- env: `DDL_AUTO=update`
 
 ## 실행 예시
 

--- a/infra/terraform/cloud_run.tf
+++ b/infra/terraform/cloud_run.tf
@@ -39,6 +39,32 @@ resource "google_cloud_run_v2_service" "app" {
         value = var.firebase_storage_bucket
       }
 
+      env {
+        name  = "DB_URL"
+        value = var.db_url
+      }
+
+      env {
+        name  = "DB_USER"
+        value = var.db_user
+      }
+
+      env {
+        name  = "DDL_AUTO"
+        value = var.ddl_auto
+      }
+
+      env {
+        name = "DB_PASSWORD"
+
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.db_password.secret_id
+            version = "latest"
+          }
+        }
+      }
+
       dynamic "env" {
         for_each = var.environment_variables
 
@@ -98,6 +124,7 @@ resource "google_cloud_run_v2_service" "app" {
   depends_on = [
     google_artifact_registry_repository_iam_member.runtime_reader,
     google_project_service.required,
+    google_secret_manager_secret_iam_member.runtime_db_password_secret_accessor,
     google_secret_manager_secret_iam_member.runtime_firebase_secret_accessor,
   ]
 }

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -32,3 +32,10 @@ resource "google_secret_manager_secret_iam_member" "runtime_firebase_secret_acce
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.runtime.email}"
 }
+
+resource "google_secret_manager_secret_iam_member" "runtime_db_password_secret_accessor" {
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.db_password.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.runtime.email}"
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -32,3 +32,8 @@ output "firebase_credentials_secret_id" {
   description = "Secret Manager secret ID for Firebase Admin SDK credentials."
   value       = google_secret_manager_secret.firebase_credentials.secret_id
 }
+
+output "db_password_secret_id" {
+  description = "Secret Manager secret ID for the application database password."
+  value       = google_secret_manager_secret.db_password.secret_id
+}

--- a/infra/terraform/secrets.tf
+++ b/infra/terraform/secrets.tf
@@ -9,3 +9,15 @@ resource "google_secret_manager_secret" "firebase_credentials" {
 
   depends_on = [google_project_service.required]
 }
+
+resource "google_secret_manager_secret" "db_password" {
+  project   = var.project_id
+  secret_id = var.db_password_secret_id
+  labels    = var.labels
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.required]
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -12,19 +12,19 @@ variable "region" {
 variable "repository_id" {
   description = "Artifact Registry Docker repository ID."
   type        = string
-  default     = "aim"
+  default     = "app-repo"
 }
 
 variable "service_name" {
   description = "Cloud Run service name."
   type        = string
-  default     = "aim-backend"
+  default     = "aim-be"
 }
 
 variable "image_name" {
   description = "Container image name inside Artifact Registry."
   type        = string
-  default     = "aim-backend"
+  default     = "aim-be"
 }
 
 variable "bootstrap_image" {
@@ -80,6 +80,30 @@ variable "firebase_storage_bucket" {
   default     = "ajou-project-cafd9.firebasestorage.app"
 }
 
+variable "db_password_secret_id" {
+  description = "Secret Manager secret ID for the application database password."
+  type        = string
+  default     = "aim-be-db-password"
+}
+
+variable "db_url" {
+  description = "JDBC URL used by the backend."
+  type        = string
+  default     = "jdbc:mysql://161.33.46.41:3306/aim?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8"
+}
+
+variable "db_user" {
+  description = "Database username used by the backend."
+  type        = string
+  default     = "aim_be"
+}
+
+variable "ddl_auto" {
+  description = "Hibernate ddl-auto mode."
+  type        = string
+  default     = "update"
+}
+
 variable "container_port" {
   description = "Container port exposed by the Spring Boot application."
   type        = number
@@ -124,9 +148,9 @@ variable "environment_variables" {
   validation {
     condition = length([
       for key in keys(var.environment_variables) : key
-      if contains(["FIREBASE_CREDENTIALS_PATH", "FIREBASE_STORAGE_BUCKET"], key)
+      if contains(["DB_PASSWORD", "DB_URL", "DB_USER", "DDL_AUTO", "FIREBASE_CREDENTIALS_PATH", "FIREBASE_STORAGE_BUCKET"], key)
     ]) == 0
-    error_message = "environment_variables must not contain FIREBASE_CREDENTIALS_PATH or FIREBASE_STORAGE_BUCKET."
+    error_message = "environment_variables must not contain DB_PASSWORD, DB_URL, DB_USER, DDL_AUTO, FIREBASE_CREDENTIALS_PATH, or FIREBASE_STORAGE_BUCKET."
   }
 }
 
@@ -134,7 +158,7 @@ variable "labels" {
   description = "Labels applied to managed Google Cloud resources."
   type        = map(string)
   default = {
-    app     = "aim-backend"
+    app     = "aim-be"
     managed = "terraform"
   }
 }

--- a/src/main/java/ajou/aim_be/global/FirebaseAdminConfig.java
+++ b/src/main/java/ajou/aim_be/global/FirebaseAdminConfig.java
@@ -29,9 +29,10 @@ public class FirebaseAdminConfig {
 
     public FirebaseAdminConfig(
             @Value("${firebase.credentials.path:}") String credentialsPath,
+            @Value("${firebase.config.path:}") String legacyConfigPath,
             @Value("${firebase.credentials.json:}") String credentialsJson,
             @Value("${firebase.storage.bucket:ajou-project-cafd9.firebasestorage.app}") String storageBucket) {
-        this.credentialsPath = credentialsPath;
+        this.credentialsPath = StringUtils.hasText(credentialsPath) ? credentialsPath : legacyConfigPath;
         this.credentialsJson = credentialsJson;
         this.storageBucket = storageBucket;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,37 @@
+server:
+  port: ${PORT:8080}
+  address: 0.0.0.0
+  forward-headers-strategy: framework
+
+spring:
+  application:
+    name: aim-be
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL:jdbc:mysql://161.33.46.41:3306/aim?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    username: ${DB_USER:aim_be}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    database: mysql
+    open-in-view: false
+    hibernate:
+      ddl-auto: ${DDL_AUTO:update}
+    properties:
+      hibernate:
+        format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul
+
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 50MB
+
+firebase:
+  credentials:
+    path: ${FIREBASE_CREDENTIALS_PATH:}
+    json: ${FIREBASE_CREDENTIALS_JSON:}
+  storage:
+    bucket: ${FIREBASE_STORAGE_BUCKET:ajou-project-cafd9.firebasestorage.app}


### PR DESCRIPTION
## 🔎 What is this PR?

- Cloud Run 배포 환경에서 외부 MySQL DB에 연결할 수 있도록 Spring Boot 런타임 설정, Secret Manager 기반 DB 비밀번호 주입, Terraform 기준 상태를 보완합니다.
- Closes #8

---

## 📝 Changes

- 안전한 기본 `src/main/resources/application.yml`을 추가해 Docker 이미지에 Spring Boot 런타임 설정이 포함되도록 수정
- `DB_URL`, `DB_USER`, `DB_PASSWORD`, `DDL_AUTO` 환경변수 기반으로 datasource 설정 정리
- `.gitignore`와 `.dockerignore`를 조정해 안전한 `application.yml`은 포함하고, 로컬/운영 설정 파일과 Firebase JSON 키는 계속 제외
- Terraform에 DB password용 Secret Manager secret container 추가
- Cloud Run `DB_PASSWORD` env를 Secret Manager latest version에서 읽도록 구성
- Cloud Run runtime service account에 DB password secret accessor 권한 추가
- deploy workflow 기본값을 현재 운영 리소스 기준으로 정리
- 기존 `firebase.config.path` 설정도 계속 읽을 수 있도록 Firebase 설정 호환성 보완
- CI/CD 운영 문서와 Terraform README에 DB secret 등록/검증 절차 반영

---

## 🔐 Secret / Runtime Config

- DB 비밀번호는 저장소, Docker image, `terraform.tfvars`, Terraform state에 평문으로 저장하지 않습니다.
- Terraform은 secret container와 Cloud Run secret env 연결만 관리합니다.
- 실제 DB password secret version은 GCP Secret Manager에 별도로 등록해야 합니다.
- Cloud Run 런타임 계약은 `DB_URL`, `DB_USER`, `DB_PASSWORD`, `DDL_AUTO` 환경변수입니다.

---

## 📚 Background / Context (선택)

- 기존 CI/CD 구성은 Firebase Secret Manager 연결은 포함했지만 DB password를 Cloud Run runtime secret env로 연결하지 않았습니다.
- `application.yml`이 Git/Docker ignore 대상이라 Docker 이미지에 datasource/runtime 설정이 포함되지 않을 수 있었습니다.
- 운영 DB는 MySQL이므로 MySQL driver와 JDBC URL 형식은 유지합니다.

## ✔ Checklist

- [x] Gradle 테스트/빌드 통과 (`./gradlew test bootJar --no-daemon`)
- [x] 비밀번호가 저장소 diff에 포함되지 않음 확인
- [x] 관련 문서 반영 (`docs/cicd-cloud-run.md`, `infra/terraform/README.md`)
- [x] Terraform 포맷/검증 통과 (`terraform fmt -check -recursive`, `terraform validate`)
- [ ] GCP 권한이 있는 실행 환경에서 `terraform plan` 확인
- [ ] GCP Secret Manager에 DB password secret version 등록
- [ ] Cloud Run 배포 후 실제 DB 연결 확인

---

## 🙏 Request

- 운영 GCP 프로젝트에서 DB password Secret Manager secret/version 등록 권한 확인 부탁드립니다.
- 현재 로컬 GCP 계정은 Secret Manager secret 조회/생성 권한이 없어 DB password secret을 직접 등록하지 못했습니다.
