### PR TITLE
[Fix] #10 - Cloud Run 배포 환경변수 주입

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -22,6 +22,11 @@ env:
   IMAGE_NAME: ${{ vars.IMAGE_NAME || 'aim-be' }}
   GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
   GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+  DB_URL: ${{ secrets.DB_URL }}
+  DB_USER: ${{ vars.DB_USER || 'aim_be' }}
+  DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+  DDL_AUTO: ${{ vars.DDL_AUTO || 'update' }}
+  FIREBASE_STORAGE_BUCKET: ${{ vars.FIREBASE_STORAGE_BUCKET || 'ajou-project-cafd9.firebasestorage.app' }}
 
 jobs:
   verify:
@@ -58,7 +63,7 @@ jobs:
       - name: Validate deployment configuration
         run: |
           missing=0
-          for name in GCP_PROJECT_ID GCP_REGION CLOUD_RUN_SERVICE ARTIFACT_REGISTRY_REPOSITORY IMAGE_NAME GCP_WORKLOAD_IDENTITY_PROVIDER GCP_SERVICE_ACCOUNT; do
+          for name in GCP_PROJECT_ID GCP_REGION CLOUD_RUN_SERVICE ARTIFACT_REGISTRY_REPOSITORY IMAGE_NAME GCP_WORKLOAD_IDENTITY_PROVIDER GCP_SERVICE_ACCOUNT DB_URL DB_USER DB_PASSWORD DDL_AUTO FIREBASE_STORAGE_BUCKET; do
             if [ -z "${!name}" ]; then
               echo "::error::${name} is required"
               missing=1
@@ -95,3 +100,9 @@ jobs:
           service: ${{ env.CLOUD_RUN_SERVICE }}
           image: ${{ env.IMAGE_URI }}
           region: ${{ env.GCP_REGION }}
+          env_vars: |-
+            DB_URL=${{ env.DB_URL }}
+            DB_USER=${{ env.DB_USER }}
+            DB_PASSWORD=${{ env.DB_PASSWORD }}
+            DDL_AUTO=${{ env.DDL_AUTO }}
+            FIREBASE_STORAGE_BUCKET=${{ env.FIREBASE_STORAGE_BUCKET }}

--- a/docs/cicd-cloud-run.md
+++ b/docs/cicd-cloud-run.md
@@ -100,14 +100,14 @@ Cloud Run runtime 계약:
 
 ## Database Credential
 
-DB는 Oracle Cloud에 올라간 MySQL을 사용한다. 애플리케이션 이미지는 비밀번호 없이 다음 환경변수 계약으로 실행된다.
+운영 DB는 MySQL을 사용한다. 애플리케이션 이미지는 비밀번호 없이 다음 환경변수 계약으로 실행된다.
 
-- `DB_URL=jdbc:mysql://161.33.46.41:3306/aim?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8`
-- `DB_USER=aim_be`
-- `DB_PASSWORD=<Secret Manager latest version>`
+- `DB_URL=<JDBC URL>`
+- `DB_USER=<DB username>`
+- `DB_PASSWORD=<GitHub Actions Secret 또는 Secret Manager latest version>`
 - `DDL_AUTO=update`
 
-DB 비밀번호는 저장소와 Terraform 변수 파일에 넣지 않고 Secret Manager secret version으로만 등록한다.
+DB 접속 정보와 비밀번호는 저장소와 Terraform 변수 파일에 넣지 않는다. 현재 GitHub Actions 배포 workflow는 `DB_URL`, `DB_PASSWORD`를 GitHub Actions Secret으로 받고, `DB_USER`, `DDL_AUTO`를 GitHub Actions Variable로 받아 Cloud Run revision 환경변수에 주입한다.
 
 ## 최초 설정 순서
 
@@ -116,7 +116,7 @@ DB 비밀번호는 저장소와 Terraform 변수 파일에 넣지 않고 Secret 
 3. `terraform init`, `terraform fmt -check`, `terraform validate`, `terraform plan`을 실행한다.
 4. 의도한 변경만 있는지 확인한 뒤 `terraform apply`를 실행한다.
 5. Firebase Admin SDK JSON을 Secret Manager secret version으로 등록한다.
-6. DB password를 Secret Manager secret version으로 등록한다.
+6. DB 접속 정보와 DB password를 GitHub Actions Secret/Variable 또는 Secret Manager secret version으로 등록한다.
 7. Terraform output `github_workload_identity_provider`를 GitHub Variable `GCP_WORKLOAD_IDENTITY_PROVIDER`에 등록한다.
 8. Terraform output `deployer_service_account_email`을 GitHub Variable `GCP_SERVICE_ACCOUNT`에 등록한다.
 9. 나머지 GitHub Variables를 등록한다.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,9 +9,9 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DB_URL:jdbc:mysql://161.33.46.41:3306/aim?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    url: ${DB_URL:jdbc:mysql://localhost:3306/aim?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
     username: ${DB_USER:aim_be}
-    password: ${DB_PASSWORD}
+    password: ${DB_PASSWORD:}
 
   jpa:
     database: mysql


### PR DESCRIPTION
## 🔎 What is this PR?

- Cloud Run 배포 workflow가 새 revision에 DB 런타임 환경변수를 명시적으로 주입하도록 보완합니다.
- Closes #10

---

## 📝 Changes

- deploy workflow 검증 단계에 DB/Firebase 런타임 설정 누락 검사를 추가
- `DB_URL`, `DB_PASSWORD`는 GitHub Actions Secret에서 읽어 Cloud Run env로 전달
- `DB_USER`, `DDL_AUTO`, `FIREBASE_STORAGE_BUCKET`은 GitHub Actions Variable에서 읽어 Cloud Run env로 전달
- 기본 `application.yml`에서 운영 DB 접속값을 제거하고 로컬 기본값으로 일반화
- CI/CD 문서에서 DB 접속 정보 저장 위치와 주입 경로를 Secret/Variable 기준으로 정리

---

## 🔐 Secret / Runtime Config

- 민감한 DB 접속 정보는 저장소와 PR 본문에 포함하지 않습니다.
- GitHub Actions Secret/Variable 등록 여부는 확인했습니다.
- Cloud Run deploy는 기존 WIF 인증과 Artifact Registry push 흐름을 유지합니다.

---

## 📚 Background / Context (선택)

- 이전 main 배포는 WIF 인증과 Docker build/push까지 성공했지만 Cloud Run revision 시작 단계에서 실패했습니다.
- 실패 지점은 CI/CD 인증 문제가 아니라 컨테이너 런타임 설정 누락 가능성이 높은 영역이었습니다.
- 이번 변경은 배포 시점에 애플리케이션이 요구하는 런타임 env를 명시적으로 전달하도록 합니다.

## ✔ Checklist

- [x] Gradle 테스트/빌드 통과 (`./gradlew test bootJar --no-daemon`)
- [x] GitHub Actions Secret/Variable 등록 확인
- [x] PR 본문에 민감한 DB 값 미기재
- [ ] main merge 후 `Deploy to Cloud Run` workflow 성공 확인

---

## 🙏 Request

- Cloud Run revision이 여전히 기동 실패하면 Cloud Run revision 로그에서 애플리케이션 startup 예외를 확인해야 합니다.
