### PR TITLE
[Chore] #14 - PR CI Docker 컨테이너 smoke test 추가

### DIFF
--- a/.github/scripts/smoke-test-docker.sh
+++ b/.github/scripts/smoke-test-docker.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="${IMAGE_NAME:-aim-backend-ci}"
+NETWORK_NAME="${NETWORK_NAME:-aim-ci-smoke}"
+MYSQL_CONTAINER="${MYSQL_CONTAINER:-aim-ci-mysql}"
+APP_CONTAINER="${APP_CONTAINER:-aim-ci-app}"
+PORT="${PORT:-8080}"
+MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-root_password}"
+
+cleanup() {
+  status=$?
+
+  if [ "${status}" -ne 0 ]; then
+    docker logs "${MYSQL_CONTAINER}" 2>/dev/null || true
+    docker logs "${APP_CONTAINER}" 2>/dev/null || true
+  fi
+
+  docker rm -f "${APP_CONTAINER}" "${MYSQL_CONTAINER}" >/dev/null 2>&1 || true
+  docker network rm "${NETWORK_NAME}" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+docker rm -f "${APP_CONTAINER}" "${MYSQL_CONTAINER}" >/dev/null 2>&1 || true
+docker network rm "${NETWORK_NAME}" >/dev/null 2>&1 || true
+
+docker network create "${NETWORK_NAME}" >/dev/null
+
+docker run \
+  --detach \
+  --name "${MYSQL_CONTAINER}" \
+  --network "${NETWORK_NAME}" \
+  --env MYSQL_DATABASE=aim \
+  --env MYSQL_USER="${DB_USER}" \
+  --env MYSQL_PASSWORD="${DB_PASSWORD}" \
+  --env MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD}" \
+  mysql:8.4 >/dev/null
+
+for attempt in $(seq 1 60); do
+  if docker exec "${MYSQL_CONTAINER}" mysqladmin ping -h 127.0.0.1 -uroot "-p${MYSQL_ROOT_PASSWORD}" --silent; then
+    break
+  fi
+
+  if [ "${attempt}" -eq 60 ]; then
+    echo "::error::MySQL container did not become ready"
+    exit 1
+  fi
+
+  sleep 2
+done
+
+docker run \
+  --detach \
+  --name "${APP_CONTAINER}" \
+  --network "${NETWORK_NAME}" \
+  --publish "${PORT}:${PORT}" \
+  --env PORT="${PORT}" \
+  --env DB_URL="${DB_URL}" \
+  --env DB_USER="${DB_USER}" \
+  --env DB_PASSWORD="${DB_PASSWORD}" \
+  --env DDL_AUTO="${DDL_AUTO}" \
+  --env FIREBASE_ENABLED=false \
+  --env FIREBASE_STORAGE_BUCKET="${FIREBASE_STORAGE_BUCKET}" \
+  "${IMAGE_NAME}" >/dev/null
+
+for attempt in $(seq 1 60); do
+  if response="$(curl -fsS "http://localhost:${PORT}/api/health" 2>/dev/null)" && [ "${response}" = "ok" ]; then
+    echo "Docker smoke test passed"
+    exit 0
+  fi
+
+  if ! docker ps --format '{{.Names}}' | grep -Fxq "${APP_CONTAINER}"; then
+    echo "::error::Application container exited before health check passed"
+    exit 1
+  fi
+
+  if [ "${attempt}" -eq 60 ]; then
+    echo "::error::Application did not respond on /api/health"
+    exit 1
+  fi
+
+  sleep 2
+done

--- a/.github/scripts/validate-runtime-env.sh
+++ b/.github/scripts/validate-runtime-env.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_vars=(
+  DB_URL
+  DB_USER
+  DB_PASSWORD
+  DDL_AUTO
+  FIREBASE_STORAGE_BUCKET
+)
+
+missing=0
+
+for name in "${required_vars[@]}"; do
+  if [ -z "${!name:-}" ]; then
+    echo "::error::${name} is required"
+    missing=1
+  fi
+done
+
+exit "${missing}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Lint GitHub Actions workflows
+        uses: rhysd/actionlint@03d0035246f3e81f36aed592ffb4bebf33a03106 # v1.7.7
+
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
@@ -30,3 +33,33 @@ jobs:
 
       - name: Test and build
         run: ./gradlew test bootJar --no-daemon
+
+      - name: Validate runtime environment contract
+        env:
+          DB_URL: jdbc:mysql://aim-ci-mysql:3306/aim?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+          DB_USER: aim_be
+          DB_PASSWORD: ci_password
+          DDL_AUTO: none
+          FIREBASE_STORAGE_BUCKET: ci-smoke-test-bucket
+        run: bash .github/scripts/validate-runtime-env.sh
+
+      - name: Build Docker image
+        env:
+          IMAGE_NAME: aim-backend-ci
+        run: |
+          if grep -Eiq '^[[:space:]]*FROM[[:space:]].+[[:space:]]+AS[[:space:]]+runtime-prebuilt([[:space:]]|$)' Dockerfile; then
+            docker build --target runtime-prebuilt --tag "${IMAGE_NAME}" .
+          else
+            docker build --tag "${IMAGE_NAME}" .
+          fi
+
+      - name: Smoke test Docker container
+        env:
+          IMAGE_NAME: aim-backend-ci
+          PORT: "8080"
+          DB_URL: jdbc:mysql://aim-ci-mysql:3306/aim?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+          DB_USER: aim_be
+          DB_PASSWORD: ci_password
+          DDL_AUTO: none
+          FIREBASE_STORAGE_BUCKET: ci-smoke-test-bucket
+        run: bash .github/scripts/smoke-test-docker.sh

--- a/docs/cicd-cloud-run.md
+++ b/docs/cicd-cloud-run.md
@@ -21,8 +21,14 @@
 - Java 17 설정
 - Gradle cache 설정
 - `./gradlew test bootJar --no-daemon`
+- GitHub Actions workflow 문법 검증 (`actionlint`)
+- PR용 더미 런타임 환경변수 계약 검증 (`DB_URL`, `DB_USER`, `DB_PASSWORD`, `DDL_AUTO`, `FIREBASE_STORAGE_BUCKET`)
+- Docker image build
+- MySQL 컨테이너와 함께 애플리케이션 컨테이너를 실행한 뒤 `/api/health` smoke test
 
-현재 저장소에는 별도 테스트 코드가 없으므로, 이 단계는 우선 컴파일과 Gradle test task 성공 여부를 보장한다. 테스트가 추가되면 같은 workflow가 회귀 테스트 gate 역할을 한다.
+현재 저장소에는 별도 테스트 코드가 없으므로, 이 단계는 컴파일과 Gradle test task 성공 여부를 먼저 보장한다. 추가로 Docker 이미지가 실제 컨테이너로 기동되고 `PORT=8080`에서 health check에 응답하는지 검증해 Cloud Run deploy 단계에서 발견되던 startup 실패를 PR 단계에서 최대한 앞당겨 잡는다.
+
+PR CI smoke test는 운영 DB나 Firebase 실계정을 사용하지 않는다. CI 안에서 MySQL 컨테이너를 임시로 띄우고, Firebase Admin SDK 초기화는 `FIREBASE_ENABLED=false`로 비활성화한다. GCP Workload Identity Federation, Cloud Run IAM, Artifact Registry push 권한처럼 실제 GCP 리소스 권한이 필요한 영역은 `Deploy to Cloud Run` workflow에서 검증한다.
 
 ### Deploy
 

--- a/src/main/java/ajou/aim_be/global/FirebaseAdminConfig.java
+++ b/src/main/java/ajou/aim_be/global/FirebaseAdminConfig.java
@@ -26,12 +26,15 @@ public class FirebaseAdminConfig {
     private final String credentialsPath;
     private final String credentialsJson;
     private final String storageBucket;
+    private final boolean firebaseEnabled;
 
     public FirebaseAdminConfig(
+            @Value("${firebase.enabled:true}") boolean firebaseEnabled,
             @Value("${firebase.credentials.path:}") String credentialsPath,
             @Value("${firebase.config.path:}") String legacyConfigPath,
             @Value("${firebase.credentials.json:}") String credentialsJson,
             @Value("${firebase.storage.bucket:ajou-project-cafd9.firebasestorage.app}") String storageBucket) {
+        this.firebaseEnabled = firebaseEnabled;
         this.credentialsPath = StringUtils.hasText(credentialsPath) ? credentialsPath : legacyConfigPath;
         this.credentialsJson = credentialsJson;
         this.storageBucket = storageBucket;
@@ -39,6 +42,10 @@ public class FirebaseAdminConfig {
 
     @PostConstruct
     public void init() {
+        if (!firebaseEnabled) {
+            return;
+        }
+
         if (!FirebaseApp.getApps().isEmpty()) {
             return;
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,7 @@ spring:
       max-request-size: 50MB
 
 firebase:
+  enabled: ${FIREBASE_ENABLED:true}
   credentials:
     path: ${FIREBASE_CREDENTIALS_PATH:}
     json: ${FIREBASE_CREDENTIALS_JSON:}


### PR DESCRIPTION
## 🔎 What is this PR?

- PR CI에서 Docker image build와 컨테이너 startup smoke test를 추가해 Cloud Run deploy 단계에서만 드러나던 기동 실패를 더 일찍 검증합니다.
- Closes #14

---

## 📝 Changes

- PR CI에 GitHub Actions workflow 문법 검증용 `actionlint` step 추가
- PR CI에 런타임 환경변수 계약 검증 step 추가
- Docker image build step 추가
  - `runtime-prebuilt` target이 있는 Dockerfile에서는 해당 target을 사용
  - 현재 main처럼 target이 없으면 Dockerfile 기본 build를 사용
- CI 전용 MySQL 컨테이너와 애플리케이션 컨테이너를 실행하고 `/api/health` 응답 확인
- `firebase.enabled` 설정을 추가해 CI smoke test에서 Firebase Admin SDK 초기화를 비활성화할 수 있게 변경
- CI/CD 문서에 PR CI smoke test 범위와 CD에 남는 GCP 권한 검증 범위를 분리해 정리

---

## 🔐 Build / Runtime Notes

- PR CI smoke test는 운영 DB와 Firebase 실계정을 사용하지 않습니다.
- CI에서는 임시 MySQL 컨테이너와 더미 런타임 값을 사용합니다.
- Firebase 초기화 비활성화는 `FIREBASE_ENABLED=false`일 때만 적용되며, 기본값은 기존처럼 활성화입니다.
- GCP Workload Identity Federation, Artifact Registry push 권한, Cloud Run IAM 권한은 실제 GCP 리소스가 필요하므로 CD workflow에서 검증합니다.
- PR 본문에는 민감한 DB 값이나 운영 secret 값을 포함하지 않았습니다.

---

## 📚 Background / Context (선택)

- 이전 실패 사례에서는 PR CI가 `test bootJar`까지만 확인했고, 컨테이너가 Cloud Run 런타임 환경에서 정상 기동하는지는 CD에서 처음 검증됐습니다.
- 이번 PR은 Dockerfile, 런타임 환경변수 계약, MySQL 연결, `PORT=8080` listen, `/api/health` 응답을 PR 단계에서 확인해 CD 실패 원인을 더 좁혀 잡기 위한 변경입니다.

## ✔ Checklist

- [x] Gradle 테스트/빌드 통과 (`./gradlew test bootJar --no-daemon`)
- [x] GitHub Actions workflow 문법 검증 (`actionlint`)
- [x] shell script 정적 검증 (`shellcheck`)
- [x] 런타임 환경변수 계약 검증 script 실행
- [x] PR CI 통과
- [x] PR 본문에 민감한 DB 값 미기재
- [ ] main merge 후 `Deploy to Cloud Run` workflow 성공 확인

---

## 🙏 Request

- 로컬 Docker daemon이 실행 중이 아니어서 실제 Docker image build와 container smoke test는 GitHub Actions에서 확인했습니다.
