### PR TITLE
[Chore] #16 - CI와 Cloud Run 배포 워크플로 책임 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -46,12 +49,7 @@ jobs:
       - name: Build Docker image
         env:
           IMAGE_NAME: aim-backend-ci
-        run: |
-          if grep -Eiq '^[[:space:]]*FROM[[:space:]].+[[:space:]]+AS[[:space:]]+runtime-prebuilt([[:space:]]|$)' Dockerfile; then
-            docker build --target runtime-prebuilt --tag "${IMAGE_NAME}" .
-          else
-            docker build --tag "${IMAGE_NAME}" .
-          fi
+        run: docker build --target runtime --tag "${IMAGE_NAME}" .
 
       - name: Smoke test Docker container
         env:

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -29,39 +29,9 @@ env:
   FIREBASE_STORAGE_BUCKET: ${{ vars.FIREBASE_STORAGE_BUCKET || 'ajou-project-cafd9.firebasestorage.app' }}
 
 jobs:
-  verify:
-    name: Gradle test and build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          distribution: temurin
-          java-version: "17"
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
-        with:
-          cache-provider: basic
-
-      - name: Test and build
-        run: ./gradlew test bootJar --no-daemon
-
-      - name: Upload bootJar artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: boot-jar
-          path: build/libs/aim-be.jar
-          if-no-files-found: error
-
   deploy:
     name: Build image and deploy
     runs-on: ubuntu-latest
-    needs: verify
 
     steps:
       - name: Checkout
@@ -93,12 +63,6 @@ jobs:
       - name: Configure Artifact Registry Docker auth
         run: gcloud auth configure-docker "${GCP_REGION}-docker.pkg.dev" --quiet
 
-      - name: Download bootJar artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: boot-jar
-          path: build/libs
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -106,7 +70,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
-          target: runtime-prebuilt
+          target: runtime
           push: true
           tags: ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.ARTIFACT_REGISTRY_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           cache-from: type=gha

--- a/docs/cicd-cloud-run.md
+++ b/docs/cicd-cloud-run.md
@@ -6,7 +6,7 @@
 - 개발 브랜치: `feature/*`
 - 병합 흐름: `feature/*`에서 `main`으로 Pull Request 생성
 - PR 하단 Checks 영역에 `CI / Gradle test and build` 결과가 표시된다.
-- `main`에 merge되면 `Deploy to Cloud Run` workflow가 실행된다.
+- `main`에 merge되면 `CI`와 `Deploy to Cloud Run` workflow가 각각 실행된다.
 
 ## GitHub Actions
 
@@ -14,7 +14,7 @@
 
 파일: `.github/workflows/ci.yml`
 
-`pull_request`가 `main`을 대상으로 열리거나 갱신될 때 실행된다.
+`pull_request`가 `main`을 대상으로 열리거나 갱신될 때, 그리고 `main` push가 발생할 때 실행된다.
 
 검증 내용:
 
@@ -28,7 +28,7 @@
 
 현재 저장소에는 별도 테스트 코드가 없으므로, 이 단계는 컴파일과 Gradle test task 성공 여부를 먼저 보장한다. 추가로 Docker 이미지가 실제 컨테이너로 기동되고 `PORT=8080`에서 health check에 응답하는지 검증해 Cloud Run deploy 단계에서 발견되던 startup 실패를 PR 단계에서 최대한 앞당겨 잡는다.
 
-PR CI smoke test는 운영 DB나 Firebase 실계정을 사용하지 않는다. CI 안에서 MySQL 컨테이너를 임시로 띄우고, Firebase Admin SDK 초기화는 `FIREBASE_ENABLED=false`로 비활성화한다. GCP Workload Identity Federation, Cloud Run IAM, Artifact Registry push 권한처럼 실제 GCP 리소스 권한이 필요한 영역은 `Deploy to Cloud Run` workflow에서 검증한다.
+CI smoke test는 운영 DB나 Firebase 실계정을 사용하지 않는다. CI 안에서 MySQL 컨테이너를 임시로 띄우고, Firebase Admin SDK 초기화는 `FIREBASE_ENABLED=false`로 비활성화한다. GCP Workload Identity Federation, Cloud Run IAM, Artifact Registry push 권한처럼 실제 GCP 리소스 권한이 필요한 영역은 `Deploy to Cloud Run` workflow에서 검증한다.
 
 ### Deploy
 
@@ -38,17 +38,17 @@ PR CI smoke test는 운영 DB나 Firebase 실계정을 사용하지 않는다. C
 
 job 구조:
 
-- `verify`: CI와 같은 `./gradlew test bootJar --no-daemon` 실행
-- `deploy`: `needs: verify`로 연결되어 검증 실패 시 실행되지 않음
+- `deploy`: 배포 설정 검증, GCP 인증, Docker image build/push, Cloud Run deploy 실행
 
 배포 내용:
 
 - GitHub OIDC와 Google Workload Identity Federation으로 GCP 인증
 - Artifact Registry Docker auth 설정
-- `verify` job에서 생성한 bootJar artifact 재사용
 - Docker Buildx cache 기반 Docker image build
 - Artifact Registry push
 - Cloud Run revision 배포
+
+`Deploy to Cloud Run` workflow는 더 이상 Gradle test/build 검증을 별도 job으로 반복하지 않는다. 코드 검증, workflow lint, Docker smoke test는 `CI` workflow가 담당하고, 배포 workflow는 Cloud Run 배포에 필요한 런타임 설정과 GCP 권한 영역에 집중한다. 현재 구조에서는 `main` push 시 `CI`와 `Deploy to Cloud Run`이 독립적으로 실행된다. 배포를 CI 성공 이후로 강제해야 한다면 branch protection 또는 `workflow_run` 기반 순차 실행을 별도 이슈로 검토한다.
 
 이미지 태그:
 
@@ -118,12 +118,17 @@ DB 접속 정보와 비밀번호는 저장소와 Terraform 변수 파일에 넣�
 
 ## Image Build Optimization
 
-Dockerfile은 로컬 빌드가 가능한 멀티 스테이지 구조를 유지한다. 기본 `runtime` target은 Docker build 내부에서 Gradle `bootJar`를 실행하고, GitHub Actions 배포는 `verify` job의 `bootJar` 결과물을 artifact로 받아 `runtime-prebuilt` target을 빌드한다.
+Dockerfile은 로컬 빌드가 가능한 멀티 스테이지 구조를 유지한다. 기본 `runtime` target은 Docker build 내부에서 Gradle `bootJar`를 실행하고, `runtime-prebuilt` target은 이미 생성된 `build/libs/aim-be.jar`를 이미지에 복사한다.
 
-배포 workflow의 이미지 최적화 계약:
+CI workflow의 이미지 검증 계약:
 
-- `verify`: `./gradlew test bootJar --no-daemon` 실행 후 `build/libs/aim-be.jar` artifact 업로드
-- `deploy`: artifact 다운로드 후 Docker 내부 Gradle 빌드 없이 `runtime-prebuilt` target 빌드
+- `./gradlew test bootJar --no-daemon` 실행
+- 배포 workflow와 같은 `runtime` target으로 Docker image build
+- CI 전용 MySQL 컨테이너와 함께 애플리케이션 컨테이너 smoke test
+
+배포 workflow의 이미지 빌드 계약:
+
+- 별도 Gradle verify job 없이 Docker Buildx로 `runtime` target build/push
 - Docker Buildx `type=gha` cache로 레이어 캐시 재사용
 - 최종 런타임 이미지는 non-root distroless Java 17 기반으로 실행
 
@@ -145,7 +150,7 @@ Dockerfile은 로컬 빌드가 가능한 멀티 스테이지 구조를 유지한
 ## 실패 대응
 
 - PR CI 실패: PR 하단 Checks에서 실패 job을 열고 Gradle compile/test 오류를 확인한다.
-- deploy `verify` 실패: image build/push/deploy는 실행되지 않는다.
+- deploy 설정 검증 실패: 필수 GitHub Variables/Secrets 값을 확인한다.
 - GCP 인증 실패: `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`, Terraform WIF provider의 repository/ref 조건을 확인한다.
 - Docker push 실패: Artifact Registry repository 이름, region, service account 권한을 확인한다.
 - Cloud Run deploy 실패: deployer service account의 `roles/run.admin`, runtime service account에 대한 `roles/iam.serviceAccountUser`, Artifact Registry reader 권한을 확인한다.


### PR DESCRIPTION
## 변경 내용

- `ci.yml`을 `main` push에서도 실행한다
- 배포 워크플로의 중복 Gradle 검증을 제거한다
- 배포 워크플로가 이미지 빌드와 배포만 담당하게 한다
- CI와 배포의 Docker 대상을 `runtime`으로 맞춘다
- 운영 문서를 현재 구조에 맞게 갱신한다

## 검증

- `actionlint`를 실행한다
- `git diff --check`를 실행한다
- `./gradlew test bootJar --no-daemon`을 실행한다
- PR CI 통과를 확인한다

## 관련 이슈

- #16
