### PR TITLE
[Fix] #18 - 운영 Hibernate ddl-auto 안전값 고정

### DIFF
--- a/.github/scripts/validate-deploy-env.sh
+++ b/.github/scripts/validate-deploy-env.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_vars=(
+  GCP_PROJECT_ID
+  GCP_REGION
+  CLOUD_RUN_SERVICE
+  ARTIFACT_REGISTRY_REPOSITORY
+  IMAGE_NAME
+  GCP_WORKLOAD_IDENTITY_PROVIDER
+  GCP_SERVICE_ACCOUNT
+  SPRING_PROFILES_ACTIVE
+)
+
+missing=0
+
+for name in "${required_vars[@]}"; do
+  if [ -z "${!name:-}" ]; then
+    echo "::error::${name} is required"
+    missing=1
+  fi
+done
+
+if [ -n "${SPRING_PROFILES_ACTIVE:-}" ] && [ "${SPRING_PROFILES_ACTIVE}" != "prod" ]; then
+  echo "::error::SPRING_PROFILES_ACTIVE must be prod for Cloud Run deployments"
+  missing=1
+fi
+
+bash .github/scripts/validate-runtime-env.sh || missing=1
+
+exit "${missing}"

--- a/.github/scripts/validate-runtime-env.sh
+++ b/.github/scripts/validate-runtime-env.sh
@@ -18,4 +18,15 @@ for name in "${required_vars[@]}"; do
   fi
 done
 
+if [ -n "${DDL_AUTO:-}" ]; then
+  case "${DDL_AUTO}" in
+    validate|none)
+      ;;
+    *)
+      echo "::error::DDL_AUTO must be validate or none for Cloud Run deployments"
+      missing=1
+      ;;
+  esac
+fi
+
 exit "${missing}"

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -22,10 +22,11 @@ env:
   IMAGE_NAME: ${{ vars.IMAGE_NAME || 'aim-be' }}
   GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
   GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+  SPRING_PROFILES_ACTIVE: prod
   DB_URL: ${{ secrets.DB_URL }}
   DB_USER: ${{ vars.DB_USER || 'aim_be' }}
   DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-  DDL_AUTO: ${{ vars.DDL_AUTO || 'update' }}
+  DDL_AUTO: ${{ vars.DDL_AUTO || 'validate' }}
   FIREBASE_STORAGE_BUCKET: ${{ vars.FIREBASE_STORAGE_BUCKET || 'ajou-project-cafd9.firebasestorage.app' }}
 
 jobs:
@@ -38,15 +39,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Validate deployment configuration
-        run: |
-          missing=0
-          for name in GCP_PROJECT_ID GCP_REGION CLOUD_RUN_SERVICE ARTIFACT_REGISTRY_REPOSITORY IMAGE_NAME GCP_WORKLOAD_IDENTITY_PROVIDER GCP_SERVICE_ACCOUNT DB_URL DB_USER DB_PASSWORD DDL_AUTO FIREBASE_STORAGE_BUCKET; do
-            if [ -z "${!name}" ]; then
-              echo "::error::${name} is required"
-              missing=1
-            fi
-          done
-          exit "${missing}"
+        run: bash .github/scripts/validate-deploy-env.sh
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
@@ -76,18 +69,15 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Export image URI
-        run: |
-          echo "IMAGE_URI=${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REGISTRY_REPOSITORY}/${IMAGE_NAME}:${GITHUB_SHA}" >> "${GITHUB_ENV}"
-
       - name: Deploy to Cloud Run
         id: deploy
         uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
         with:
           service: ${{ env.CLOUD_RUN_SERVICE }}
-          image: ${{ env.IMAGE_URI }}
+          image: ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.ARTIFACT_REGISTRY_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           region: ${{ env.GCP_REGION }}
           env_vars: |-
+            SPRING_PROFILES_ACTIVE=${{ env.SPRING_PROFILES_ACTIVE }}
             DB_URL=${{ env.DB_URL }}
             DB_USER=${{ env.DB_USER }}
             DB_PASSWORD=${{ env.DB_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ out/
 .vscode/
 
 src/main/resources/firebase/ajou-project-cafd9-firebase-adminsdk-fbsvc-e6d8a32d57.json
-src/main/resources/application-prod.yml
 src/main/resources/application-local.yml
 
 docker-compose.yml

--- a/docs/cicd-cloud-run.md
+++ b/docs/cicd-cloud-run.md
@@ -112,9 +112,10 @@ Cloud Run runtime 계약:
 - `DB_URL=<JDBC URL>`
 - `DB_USER=<DB username>`
 - `DB_PASSWORD=<GitHub Actions Secret 또는 Secret Manager latest version>`
-- `DDL_AUTO=update`
+- `SPRING_PROFILES_ACTIVE=prod`
+- `DDL_AUTO=validate`
 
-DB 접속 정보와 비밀번호는 저장소와 Terraform 변수 파일에 넣지 않는다. 현재 GitHub Actions 배포 workflow는 `DB_URL`, `DB_PASSWORD`를 GitHub Actions Secret으로 받고, `DB_USER`, `DDL_AUTO`를 GitHub Actions Variable로 받아 Cloud Run revision 환경변수에 주입한다.
+DB 접속 정보와 비밀번호는 저장소와 Terraform 변수 파일에 넣지 않는다. 현재 GitHub Actions 배포 workflow는 `DB_URL`, `DB_PASSWORD`를 GitHub Actions Secret으로 받고, `DB_USER`, `DDL_AUTO`를 GitHub Actions Variable로 받아 Cloud Run revision 환경변수에 주입한다. 운영 환경에서는 Hibernate가 스키마를 자동 생성하거나 삭제하지 않도록 `DDL_AUTO` 기본값을 `validate`로 두고, Cloud Run 배포에서는 `validate` 또는 `none`만 허용한다.
 
 ## Image Build Optimization
 

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -73,7 +73,10 @@ Cloud Run에는 다음 계약으로 주입된다.
 - env: `DB_URL=<JDBC URL>`
 - env: `DB_USER=aim_be`
 - env: `DB_PASSWORD=<Secret Manager latest version>`
-- env: `DDL_AUTO=update`
+- env: `SPRING_PROFILES_ACTIVE=prod`
+- env: `DDL_AUTO=validate`
+
+`DDL_AUTO`는 운영 DB 스키마 자동 삭제/생성을 막기 위해 `validate` 또는 `none`만 허용한다.
 
 ## 실행 예시
 

--- a/infra/terraform/cloud_run.tf
+++ b/infra/terraform/cloud_run.tf
@@ -30,6 +30,11 @@ resource "google_cloud_run_v2_service" "app" {
       }
 
       env {
+        name  = "SPRING_PROFILES_ACTIVE"
+        value = var.spring_profiles_active
+      }
+
+      env {
         name  = "FIREBASE_CREDENTIALS_PATH"
         value = local.firebase_credentials_path
       }

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -98,10 +98,21 @@ variable "db_user" {
   default     = "aim_be"
 }
 
+variable "spring_profiles_active" {
+  description = "Spring profile activated in the Cloud Run runtime."
+  type        = string
+  default     = "prod"
+}
+
 variable "ddl_auto" {
   description = "Hibernate ddl-auto mode."
   type        = string
-  default     = "update"
+  default     = "validate"
+
+  validation {
+    condition     = contains(["validate", "none"], var.ddl_auto)
+    error_message = "ddl_auto must be validate or none for Cloud Run deployments."
+  }
 }
 
 variable "container_port" {
@@ -148,9 +159,9 @@ variable "environment_variables" {
   validation {
     condition = length([
       for key in keys(var.environment_variables) : key
-      if contains(["DB_PASSWORD", "DB_URL", "DB_USER", "DDL_AUTO", "FIREBASE_CREDENTIALS_PATH", "FIREBASE_STORAGE_BUCKET"], key)
+      if contains(["DB_PASSWORD", "DB_URL", "DB_USER", "DDL_AUTO", "SPRING_PROFILES_ACTIVE", "FIREBASE_CREDENTIALS_PATH", "FIREBASE_STORAGE_BUCKET"], key)
     ]) == 0
-    error_message = "environment_variables must not contain DB_PASSWORD, DB_URL, DB_USER, DDL_AUTO, FIREBASE_CREDENTIALS_PATH, or FIREBASE_STORAGE_BUCKET."
+    error_message = "environment_variables must not contain DB_PASSWORD, DB_URL, DB_USER, DDL_AUTO, SPRING_PROFILES_ACTIVE, FIREBASE_CREDENTIALS_PATH, or FIREBASE_STORAGE_BUCKET."
   }
 }
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,5 @@
+spring:
+  jpa:
+    hibernate:
+      # Keep production schema management read-only. Do not store secrets in this file.
+      ddl-auto: ${DDL_AUTO:validate}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
     database: mysql
     open-in-view: false
     hibernate:
-      ddl-auto: ${DDL_AUTO:update}
+      ddl-auto: ${DDL_AUTO:validate}
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 🔎 What is this PR?

- 운영 Cloud Run 배포에서 Hibernate가 애플리케이션 기동 시 DB 스키마를 자동 삭제/재생성하지 못하도록 `ddl-auto` 기본값과 배포 검증을 안전값으로 고정합니다.
- Closes #18

---

## 📝 Changes

- 기본 `spring.jpa.hibernate.ddl-auto` fallback을 `validate`로 변경
- 비밀값 없는 `application-prod.yml`을 추적 대상으로 추가하고 prod 프로파일에서도 `ddl-auto=validate` 기본값 유지
- deploy workflow가 `SPRING_PROFILES_ACTIVE=prod`와 `DDL_AUTO=validate`를 Cloud Run revision에 명시적으로 주입
- 배포 필수값 검증을 `.github/scripts/validate-deploy-env.sh`로 분리해 workflow inline script를 축소
- runtime env 검증 스크립트에서 `DDL_AUTO`를 `validate` 또는 `none`만 허용하도록 차단
- Terraform Cloud Run baseline에 `SPRING_PROFILES_ACTIVE=prod` 주입을 추가하고 `ddl_auto` 기본값/validation을 `validate` 또는 `none`으로 제한
- CI/CD 문서와 Terraform README의 운영 DB 런타임 계약을 `DDL_AUTO=validate` 기준으로 갱신

---

## 🔐 Runtime / Schema Safety Notes

- 운영 배포에서는 Hibernate가 `create`, `create-drop`, `update` 모드로 스키마 DDL을 실행하지 못하게 합니다.
- `validate`는 Entity와 DB 스키마가 맞는지 확인만 하고, 테이블을 생성/삭제하지 않습니다.
- `none`은 Hibernate 스키마 관리를 완전히 비활성화할 때만 허용합니다.
- PR 본문과 tracked prod 설정 파일에는 DB 비밀번호, Firebase credential, 운영 secret 값을 포함하지 않았습니다.

---

## 📚 Background / Context (트러블슈팅 과정)

- 데이터 유실 가능성 확인을 위해 `aim-be-prod` Cloud Run 로그를 먼저 조회했습니다.
- 최근 삭제성 API 호출 흔적은 확인되지 않았고, `2026-05-18 09:52 KST` 전후 `aim-be-prod-00026-jck` 리비전에서 Hibernate 스키마 DDL 로그가 확인됐습니다.
- 해당 로그에는 `SchemaDropperImpl`, `SchemaCreatorImpl`, `drop foreign key`, `create table attachments`, `create table comments`, `create table users`, `alter table posts` 등이 포함되어 있었습니다.
- 현재 main의 `application.yml`은 `DDL_AUTO:update`였지만, 실제 운영 리비전은 Cloud Run source deploy 산출물에서 빌드된 이미지였습니다.
- `aim-be-prod-00026-jck` 리비전 메타데이터의 source ZIP을 내려받아 확인한 결과, 당시 배포 소스의 `src/main/resources/application-prod.yml`은 `ddl-auto: ${DDL_AUTO:create}` 기본값을 가지고 있었습니다.
- 같은 리비전의 Cloud Run env에는 `SPRING_PROFILES_ACTIVE=prod`만 있고 `DDL_AUTO` override가 없어서, prod 기본값 `create`가 적용됐을 가능성이 높다고 판단했습니다.
- 그래서 이번 PR은 현재 main의 fallback만 바꾸지 않고, prod profile, GitHub Actions deploy, Terraform baseline, 배포 전 검증까지 같은 안전 계약으로 맞춥니다.

## ✔ Checklist

- [x] Gradle 테스트/빌드 통과 (`./gradlew test bootJar --no-daemon`)
- [x] GitHub Actions workflow 문법 검증 (`actionlint .github/workflows/ci.yml .github/workflows/deploy-cloud-run.yml`)
- [x] whitespace 검증 (`git diff --check`)
- [x] deploy env 검증 script에서 `DDL_AUTO=validate` 허용 확인
- [x] deploy env 검증 script에서 `DDL_AUTO=create` 거부 확인
- [x] PR 본문과 diff에 민감한 DB 값 미기재
- [ ] PR CI 통과
- [ ] main merge 후 `Deploy to Cloud Run` workflow 성공 확인
- [ ] 배포 후 Cloud Run revision env에 `SPRING_PROFILES_ACTIVE=prod`, `DDL_AUTO=validate` 반영 확인

---

## 🙏 Request

- 로컬에 `terraform`/`tofu`가 없어 Terraform fmt/validate는 실행하지 못했습니다. Terraform 가능 환경에서 `terraform fmt -check`와 `terraform validate` 확인 부탁드립니다.
- Docker daemon이 로컬에서 실행 중이 아니어서 Docker image build와 container smoke test는 GitHub Actions에서 확인합니다.
- 운영 GitHub Actions Variable `DDL_AUTO`가 남아 있다면 `validate` 또는 `none`인지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented stricter production deployment validation to ensure all required environment variables are configured before deployment.
  * Changed database schema management strategy in production from automatic updates to read-only validation, preventing unintended schema modifications.
  * Added production profile configuration with explicit environment settings for Cloud Run deployments.
  * Updated deployment documentation to reflect new environment requirements and schema management policies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-industry-matching/aim-backend/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->