### PR TITLE
[Fix] #20 - 운영 Cloud Run 배포 대상 정렬

### DIFF
--- a/.github/scripts/smoke-test-docker.sh
+++ b/.github/scripts/smoke-test-docker.sh
@@ -60,6 +60,7 @@ docker run \
   --env DB_USER="${DB_USER}" \
   --env DB_PASSWORD="${DB_PASSWORD}" \
   --env DDL_AUTO="${DDL_AUTO}" \
+  --env SPRING_JPA_HIBERNATE_DDL_AUTO="${SPRING_JPA_HIBERNATE_DDL_AUTO}" \
   --env FIREBASE_ENABLED=false \
   --env FIREBASE_STORAGE_BUCKET="${FIREBASE_STORAGE_BUCKET}" \
   "${IMAGE_NAME}" >/dev/null

--- a/.github/scripts/validate-deploy-env.sh
+++ b/.github/scripts/validate-deploy-env.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 required_vars=(
   GCP_PROJECT_ID
-  GCP_REGION
+  CLOUD_RUN_REGION
   CLOUD_RUN_SERVICE
+  ARTIFACT_REGISTRY_REGION
   ARTIFACT_REGISTRY_REPOSITORY
   IMAGE_NAME
   GCP_WORKLOAD_IDENTITY_PROVIDER
@@ -20,6 +21,16 @@ for name in "${required_vars[@]}"; do
     missing=1
   fi
 done
+
+if [ -n "${CLOUD_RUN_REGION:-}" ] && [ "${CLOUD_RUN_REGION}" != "us-central1" ]; then
+  echo "::error::CLOUD_RUN_REGION must be us-central1 for aim-be-prod deployments"
+  missing=1
+fi
+
+if [ -n "${CLOUD_RUN_SERVICE:-}" ] && [ "${CLOUD_RUN_SERVICE}" != "aim-be-prod" ]; then
+  echo "::error::CLOUD_RUN_SERVICE must be aim-be-prod for production deployments"
+  missing=1
+fi
 
 if [ -n "${SPRING_PROFILES_ACTIVE:-}" ] && [ "${SPRING_PROFILES_ACTIVE}" != "prod" ]; then
   echo "::error::SPRING_PROFILES_ACTIVE must be prod for Cloud Run deployments"

--- a/.github/scripts/validate-runtime-env.sh
+++ b/.github/scripts/validate-runtime-env.sh
@@ -6,6 +6,7 @@ required_vars=(
   DB_USER
   DB_PASSWORD
   DDL_AUTO
+  SPRING_JPA_HIBERNATE_DDL_AUTO
   FIREBASE_STORAGE_BUCKET
 )
 
@@ -24,6 +25,17 @@ if [ -n "${DDL_AUTO:-}" ]; then
       ;;
     *)
       echo "::error::DDL_AUTO must be validate or none for Cloud Run deployments"
+      missing=1
+      ;;
+  esac
+fi
+
+if [ -n "${SPRING_JPA_HIBERNATE_DDL_AUTO:-}" ]; then
+  case "${SPRING_JPA_HIBERNATE_DDL_AUTO}" in
+    validate|none)
+      ;;
+    *)
+      echo "::error::SPRING_JPA_HIBERNATE_DDL_AUTO must be validate or none for Cloud Run deployments"
       missing=1
       ;;
   esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           DB_USER: aim_be
           DB_PASSWORD: ci_password
           DDL_AUTO: none
+          SPRING_JPA_HIBERNATE_DDL_AUTO: none
           FIREBASE_STORAGE_BUCKET: ci-smoke-test-bucket
         run: bash .github/scripts/validate-runtime-env.sh
 
@@ -59,5 +60,6 @@ jobs:
           DB_USER: aim_be
           DB_PASSWORD: ci_password
           DDL_AUTO: none
+          SPRING_JPA_HIBERNATE_DDL_AUTO: none
           FIREBASE_STORAGE_BUCKET: ci-smoke-test-bucket
         run: bash .github/scripts/smoke-test-docker.sh

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -16,10 +16,11 @@ concurrency:
 
 env:
   GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
-  GCP_REGION: ${{ vars.GCP_REGION || 'asia-northeast3' }}
-  CLOUD_RUN_SERVICE: ${{ vars.CLOUD_RUN_SERVICE || 'aim-be' }}
-  ARTIFACT_REGISTRY_REPOSITORY: ${{ vars.ARTIFACT_REGISTRY_REPOSITORY || 'app-repo' }}
-  IMAGE_NAME: ${{ vars.IMAGE_NAME || 'aim-be' }}
+  CLOUD_RUN_REGION: us-central1
+  CLOUD_RUN_SERVICE: aim-be-prod
+  ARTIFACT_REGISTRY_REGION: asia-northeast3
+  ARTIFACT_REGISTRY_REPOSITORY: app-repo
+  IMAGE_NAME: aim-be
   GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
   GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
   SPRING_PROFILES_ACTIVE: prod
@@ -27,6 +28,7 @@ env:
   DB_USER: ${{ vars.DB_USER || 'aim_be' }}
   DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
   DDL_AUTO: ${{ vars.DDL_AUTO || 'validate' }}
+  SPRING_JPA_HIBERNATE_DDL_AUTO: ${{ vars.DDL_AUTO || 'validate' }}
   FIREBASE_STORAGE_BUCKET: ${{ vars.FIREBASE_STORAGE_BUCKET || 'ajou-project-cafd9.firebasestorage.app' }}
 
 jobs:
@@ -54,7 +56,7 @@ jobs:
           project_id: ${{ env.GCP_PROJECT_ID }}
 
       - name: Configure Artifact Registry Docker auth
-        run: gcloud auth configure-docker "${GCP_REGION}-docker.pkg.dev" --quiet
+        run: gcloud auth configure-docker "${ARTIFACT_REGISTRY_REGION}-docker.pkg.dev" --quiet
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -65,7 +67,7 @@ jobs:
           context: .
           target: runtime
           push: true
-          tags: ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.ARTIFACT_REGISTRY_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          tags: ${{ env.ARTIFACT_REGISTRY_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.ARTIFACT_REGISTRY_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -74,12 +76,13 @@ jobs:
         uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
         with:
           service: ${{ env.CLOUD_RUN_SERVICE }}
-          image: ${{ env.GCP_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.ARTIFACT_REGISTRY_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
-          region: ${{ env.GCP_REGION }}
+          image: ${{ env.ARTIFACT_REGISTRY_REGION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.ARTIFACT_REGISTRY_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          region: ${{ env.CLOUD_RUN_REGION }}
           env_vars: |-
             SPRING_PROFILES_ACTIVE=${{ env.SPRING_PROFILES_ACTIVE }}
             DB_URL=${{ env.DB_URL }}
             DB_USER=${{ env.DB_USER }}
             DB_PASSWORD=${{ env.DB_PASSWORD }}
             DDL_AUTO=${{ env.DDL_AUTO }}
+            SPRING_JPA_HIBERNATE_DDL_AUTO=${{ env.SPRING_JPA_HIBERNATE_DDL_AUTO }}
             FIREBASE_STORAGE_BUCKET=${{ env.FIREBASE_STORAGE_BUCKET }}

--- a/docs/cicd-cloud-run.md
+++ b/docs/cicd-cloud-run.md
@@ -22,7 +22,7 @@
 - Gradle cache 설정
 - `./gradlew test bootJar --no-daemon`
 - GitHub Actions workflow 문법 검증 (`actionlint`)
-- PR용 더미 런타임 환경변수 계약 검증 (`DB_URL`, `DB_USER`, `DB_PASSWORD`, `DDL_AUTO`, `FIREBASE_STORAGE_BUCKET`)
+- PR용 더미 런타임 환경변수 계약 검증 (`DB_URL`, `DB_USER`, `DB_PASSWORD`, `DDL_AUTO`, `SPRING_JPA_HIBERNATE_DDL_AUTO`, `FIREBASE_STORAGE_BUCKET`)
 - Docker image build
 - MySQL 컨테이너와 함께 애플리케이션 컨테이너를 실행한 뒤 `/api/health` smoke test
 
@@ -46,15 +46,17 @@ job 구조:
 - Artifact Registry Docker auth 설정
 - Docker Buildx cache 기반 Docker image build
 - Artifact Registry push
-- Cloud Run revision 배포
+- 운영 Cloud Run service `aim-be-prod` revision 배포
 
 `Deploy to Cloud Run` workflow는 더 이상 Gradle test/build 검증을 별도 job으로 반복하지 않는다. 코드 검증, workflow lint, Docker smoke test는 `CI` workflow가 담당하고, 배포 workflow는 Cloud Run 배포에 필요한 런타임 설정과 GCP 권한 영역에 집중한다. 현재 구조에서는 `main` push 시 `CI`와 `Deploy to Cloud Run`이 독립적으로 실행된다. 배포를 CI 성공 이후로 강제해야 한다면 branch protection 또는 `workflow_run` 기반 순차 실행을 별도 이슈로 검토한다.
 
 이미지 태그:
 
 ```text
-<REGION>-docker.pkg.dev/<PROJECT_ID>/<REPOSITORY>/<IMAGE_NAME>:<GITHUB_SHA>
+<ARTIFACT_REGISTRY_REGION>-docker.pkg.dev/<PROJECT_ID>/<REPOSITORY>/<IMAGE_NAME>:<GITHUB_SHA>
 ```
+
+현재 운영 프론트의 Firebase Hosting rewrite는 `/api/**` 요청을 `aim-be-prod`의 `us-central1` service로 전달한다. 따라서 백엔드 배포 workflow도 실제 운영 API인 `aim-be-prod`를 배포 대상으로 고정한다. 기존 `aim-be` service는 운영 프론트가 바라보지 않는 레거시 service로 취급한다.
 
 ## GitHub Variables
 
@@ -63,12 +65,21 @@ Repository Settings > Secrets and variables > Actions > Variables에 등록한�
 | 이름 | 예시 | 설명 |
 | --- | --- | --- |
 | `GCP_PROJECT_ID` | `my-project` | Google Cloud project ID |
-| `GCP_REGION` | `asia-northeast3` | Cloud Run 및 Artifact Registry region |
-| `CLOUD_RUN_SERVICE` | `aim-be` | Cloud Run service name |
-| `ARTIFACT_REGISTRY_REPOSITORY` | `app-repo` | Artifact Registry repository ID |
-| `IMAGE_NAME` | `aim-be` | Docker image name |
 | `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/123456789/locations/global/workloadIdentityPools/aim-backend-github/providers/github` | Terraform output `github_workload_identity_provider` |
 | `GCP_SERVICE_ACCOUNT` | `github-actions-deployer@my-project.iam.gserviceaccount.com` | Terraform output `deployer_service_account_email` |
+| `DB_USER` | `aim_be` | DB username. 미등록 시 workflow 기본값 사용 |
+| `DDL_AUTO` | `validate` | Hibernate ddl-auto mode. `validate` 또는 `none`만 허용 |
+| `FIREBASE_STORAGE_BUCKET` | `ajou-project-cafd9.firebasestorage.app` | Firebase Storage bucket. 미등록 시 workflow 기본값 사용 |
+
+운영 배포 대상은 workflow에 명시한다.
+
+| 이름 | 값 | 설명 |
+| --- | --- | --- |
+| `CLOUD_RUN_REGION` | `us-central1` | 실제 운영 Cloud Run region |
+| `CLOUD_RUN_SERVICE` | `aim-be-prod` | 실제 운영 Cloud Run service |
+| `ARTIFACT_REGISTRY_REGION` | `asia-northeast3` | 기존 `app-repo`가 있는 Artifact Registry region |
+| `ARTIFACT_REGISTRY_REPOSITORY` | `app-repo` | Artifact Registry repository ID |
+| `IMAGE_NAME` | `aim-be` | Docker image name |
 
 ## GitHub Secrets
 
@@ -114,8 +125,9 @@ Cloud Run runtime 계약:
 - `DB_PASSWORD=<GitHub Actions Secret 또는 Secret Manager latest version>`
 - `SPRING_PROFILES_ACTIVE=prod`
 - `DDL_AUTO=validate`
+- `SPRING_JPA_HIBERNATE_DDL_AUTO=validate`
 
-DB 접속 정보와 비밀번호는 저장소와 Terraform 변수 파일에 넣지 않는다. 현재 GitHub Actions 배포 workflow는 `DB_URL`, `DB_PASSWORD`를 GitHub Actions Secret으로 받고, `DB_USER`, `DDL_AUTO`를 GitHub Actions Variable로 받아 Cloud Run revision 환경변수에 주입한다. 운영 환경에서는 Hibernate가 스키마를 자동 생성하거나 삭제하지 않도록 `DDL_AUTO` 기본값을 `validate`로 두고, Cloud Run 배포에서는 `validate` 또는 `none`만 허용한다.
+DB 접속 정보와 비밀번호는 저장소와 Terraform 변수 파일에 넣지 않는다. 현재 GitHub Actions 배포 workflow는 `DB_URL`, `DB_PASSWORD`를 GitHub Actions Secret으로 받고, `DB_USER`, `DDL_AUTO`를 GitHub Actions Variable로 받아 Cloud Run revision 환경변수에 주입한다. 운영 환경에서는 Hibernate가 스키마를 자동 생성하거나 삭제하지 않도록 `DDL_AUTO`와 `SPRING_JPA_HIBERNATE_DDL_AUTO` 기본값을 `validate`로 두고, Cloud Run 배포에서는 `validate` 또는 `none`만 허용한다.
 
 ## Image Build Optimization
 
@@ -153,7 +165,7 @@ CI workflow의 이미지 검증 계약:
 - PR CI 실패: PR 하단 Checks에서 실패 job을 열고 Gradle compile/test 오류를 확인한다.
 - deploy 설정 검증 실패: 필수 GitHub Variables/Secrets 값을 확인한다.
 - GCP 인증 실패: `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`, Terraform WIF provider의 repository/ref 조건을 확인한다.
-- Docker push 실패: Artifact Registry repository 이름, region, service account 권한을 확인한다.
-- Cloud Run deploy 실패: deployer service account의 `roles/run.admin`, runtime service account에 대한 `roles/iam.serviceAccountUser`, Artifact Registry reader 권한을 확인한다.
+- Docker push 실패: Artifact Registry repository 이름, `ARTIFACT_REGISTRY_REGION`, service account 권한을 확인한다.
+- Cloud Run deploy 실패: `CLOUD_RUN_REGION`, `CLOUD_RUN_SERVICE`, deployer service account의 `roles/run.admin`, runtime service account에 대한 `roles/iam.serviceAccountUser`, Artifact Registry reader 권한을 확인한다.
 - DB 연결 실패: `DB_PASSWORD` secret version 존재 여부, Cloud Run runtime service account의 secret accessor 권한, `DB_URL`/`DB_USER` 값을 확인한다.
 - Firebase 초기화 실패: Secret Manager secret version 존재 여부, runtime service account의 secret accessor 권한, `FIREBASE_CREDENTIALS_PATH` mount를 확인한다.

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -75,8 +75,9 @@ Cloud Run에는 다음 계약으로 주입된다.
 - env: `DB_PASSWORD=<Secret Manager latest version>`
 - env: `SPRING_PROFILES_ACTIVE=prod`
 - env: `DDL_AUTO=validate`
+- env: `SPRING_JPA_HIBERNATE_DDL_AUTO=validate`
 
-`DDL_AUTO`는 운영 DB 스키마 자동 삭제/생성을 막기 위해 `validate` 또는 `none`만 허용한다.
+`DDL_AUTO`와 `SPRING_JPA_HIBERNATE_DDL_AUTO`는 운영 DB 스키마 자동 삭제/생성을 막기 위해 `validate` 또는 `none`만 허용한다.
 
 ## 실행 예시
 
@@ -86,7 +87,10 @@ terraform fmt -check
 terraform validate
 terraform plan \
   -var="project_id=<PROJECT_ID>" \
-  -var="bootstrap_image=<REGION>-docker.pkg.dev/<PROJECT_ID>/<REPOSITORY>/aim-backend:bootstrap"
+  -var="cloud_run_region=us-central1" \
+  -var="artifact_registry_region=asia-northeast3" \
+  -var="service_name=aim-be-prod" \
+  -var="bootstrap_image=<ARTIFACT_REGISTRY_REGION>-docker.pkg.dev/<PROJECT_ID>/<REPOSITORY>/aim-backend:bootstrap"
 ```
 
 기존 Cloud Run 서비스가 이미 있다면 새로 만들기 전에 import를 먼저 한다.
@@ -94,7 +98,7 @@ terraform plan \
 ```bash
 terraform import \
   'google_cloud_run_v2_service.app' \
-  'projects/<PROJECT_ID>/locations/<REGION>/services/<SERVICE_NAME>'
+  'projects/<PROJECT_ID>/locations/us-central1/services/aim-be-prod'
 ```
 
 import 후 `terraform plan`에서 의도하지 않은 service account, secret, env, ingress 변경이 없는지 확인한다.

--- a/infra/terraform/artifact_registry.tf
+++ b/infra/terraform/artifact_registry.tf
@@ -1,6 +1,6 @@
 resource "google_artifact_registry_repository" "app" {
   project       = var.project_id
-  location      = var.region
+  location      = var.artifact_registry_region
   repository_id = var.repository_id
   description   = "Docker images for ${var.service_name}."
   format        = "DOCKER"

--- a/infra/terraform/cloud_run.tf
+++ b/infra/terraform/cloud_run.tf
@@ -9,7 +9,7 @@ locals {
 resource "google_cloud_run_v2_service" "app" {
   project             = var.project_id
   name                = var.service_name
-  location            = var.region
+  location            = var.cloud_run_region
   ingress             = var.ingress
   labels              = var.labels
   deletion_protection = var.deletion_protection
@@ -56,6 +56,11 @@ resource "google_cloud_run_v2_service" "app" {
 
       env {
         name  = "DDL_AUTO"
+        value = var.ddl_auto
+      }
+
+      env {
+        name  = "SPRING_JPA_HIBERNATE_DDL_AUTO"
         value = var.ddl_auto
       }
 

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -1,4 +1,4 @@
 provider "google" {
   project = var.project_id
-  region  = var.region
+  region  = var.cloud_run_region
 }

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -4,7 +4,19 @@ variable "project_id" {
 }
 
 variable "region" {
-  description = "Google Cloud region for Artifact Registry and Cloud Run."
+  description = "Default Google Cloud region kept for backwards-compatible Terraform input."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "cloud_run_region" {
+  description = "Google Cloud region for the production Cloud Run service."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "artifact_registry_region" {
+  description = "Google Cloud region for the Artifact Registry Docker repository."
   type        = string
   default     = "asia-northeast3"
 }
@@ -18,7 +30,7 @@ variable "repository_id" {
 variable "service_name" {
   description = "Cloud Run service name."
   type        = string
-  default     = "aim-be"
+  default     = "aim-be-prod"
 }
 
 variable "image_name" {
@@ -159,9 +171,9 @@ variable "environment_variables" {
   validation {
     condition = length([
       for key in keys(var.environment_variables) : key
-      if contains(["DB_PASSWORD", "DB_URL", "DB_USER", "DDL_AUTO", "SPRING_PROFILES_ACTIVE", "FIREBASE_CREDENTIALS_PATH", "FIREBASE_STORAGE_BUCKET"], key)
+      if contains(["DB_PASSWORD", "DB_URL", "DB_USER", "DDL_AUTO", "SPRING_JPA_HIBERNATE_DDL_AUTO", "SPRING_PROFILES_ACTIVE", "FIREBASE_CREDENTIALS_PATH", "FIREBASE_STORAGE_BUCKET"], key)
     ]) == 0
-    error_message = "environment_variables must not contain DB_PASSWORD, DB_URL, DB_USER, DDL_AUTO, SPRING_PROFILES_ACTIVE, FIREBASE_CREDENTIALS_PATH, or FIREBASE_STORAGE_BUCKET."
+    error_message = "environment_variables must not contain DB_PASSWORD, DB_URL, DB_USER, DDL_AUTO, SPRING_JPA_HIBERNATE_DDL_AUTO, SPRING_PROFILES_ACTIVE, FIREBASE_CREDENTIALS_PATH, or FIREBASE_STORAGE_BUCKET."
   }
 }
 


### PR DESCRIPTION
## 🔎 What is this PR?

- 실제 프론트 운영 API가 호출하는 Cloud Run 서비스인 `aim-be-prod`로 백엔드 배포 대상을 정렬합니다.
- 기존 배포 workflow는 `aim-be`로 새 revision을 배포하고 있었고, 프론트 Firebase Hosting rewrite는 `aim-be-prod`를 바라보고 있어 운영 반영 경로가 어긋나 있었습니다.
- Closes #20

---

## 📝 Change

- `Deploy to Cloud Run` workflow의 운영 배포 대상을 `aim-be-prod`, `us-central1`로 고정
- Cloud Run region과 Artifact Registry region을 분리
  - Cloud Run: `us-central1`
  - Artifact Registry: `asia-northeast3`의 기존 `app-repo`
- 운영 revision에 `SPRING_JPA_HIBERNATE_DDL_AUTO`를 함께 주입해 Spring 직접 환경변수 override까지 안전값으로 고정
- 배포 검증 스크립트에서 운영 대상이 `aim-be-prod/us-central1`이 아니면 실패하도록 차단
- 런타임 검증 스크립트에서 `DDL_AUTO`와 `SPRING_JPA_HIBERNATE_DDL_AUTO` 모두 `validate` 또는 `none`만 허용
- CI smoke test 환경에도 `SPRING_JPA_HIBERNATE_DDL_AUTO=none`을 추가
- Terraform 기준 상태에서 Cloud Run region과 Artifact Registry region을 분리하고 기본 운영 service를 `aim-be-prod`로 정리
- CI/CD 문서와 Terraform README에 실제 운영 배포 경로와 레거시 `aim-be` 상태를 반영

---

## 🔐 운영 배포 안전장치

- 운영 프론트의 `/api/**` 요청은 Firebase Hosting rewrite를 통해 `aim-be-prod`로 전달됩니다.
- 이 PR 이후 main 배포는 실제 운영 API인 `aim-be-prod`에 반영됩니다.
- `aim-be`는 운영 프론트가 바라보지 않는 레거시 서비스로 취급합니다.
- Hibernate DDL 실행 방지를 위해 `DDL_AUTO`와 `SPRING_JPA_HIBERNATE_DDL_AUTO`를 함께 검증합니다.

---

## 📚 배경 / 트러블슈팅 과정

- 사용자 확인 중 실제 API 호출 URL이 `https://aim-be-prod-926871086070.us-central1.run.app/api/posts/NOTICE?page=0&size=10` 형태임을 확인했습니다.
- 프론트 `firebase.json`에서도 `/api/**` rewrite 대상이 `aim-be-prod`, `us-central1`로 설정되어 있었습니다.
- Cloud Run request log에서 `2026-05-26 23:20:41 KST`에 `aim-be-prod`가 `POST /api/auth/login` 요청을 받은 것도 확인했습니다.
- 반면 백엔드 GitHub Actions 배포 workflow는 `aim-be`, `asia-northeast3`로 배포하고 있었습니다.
- 이 불일치 때문에 `aim-be`에는 안전 패치가 배포됐지만, 실제 프론트가 호출하는 `aim-be-prod`에는 오래된 source-deploy revision이 남아 있었습니다.
- `aim-be-prod`의 구 revision에서는 `SchemaDropperImpl`, `SchemaCreatorImpl`, `create table` 로그가 확인되어 DB 초기화 위험이 재발했습니다.
- 그래서 임시로 `aim-be-prod`에 `DDL_AUTO=validate`, `SPRING_JPA_HIBERNATE_DDL_AUTO=validate`를 적용했고, 이번 PR은 그 운영 경로를 코드와 배포 기준 상태에 반영합니다.

## ✔ 확인

- [x] Gradle 테스트/빌드 통과 (`./gradlew test bootJar --no-daemon`)
- [x] GitHub Actions workflow 문법 검증 (`actionlint .github/workflows/ci.yml .github/workflows/deploy-cloud-run.yml`)
- [x] whitespace 검증 (`git diff --check`)
- [x] 배포 검증 script에서 `aim-be-prod/us-central1` 정상 케이스 통과 확인
- [x] 배포 검증 script에서 잘못된 Cloud Run region 거부 확인
- [x] 런타임 검증 script에서 `DDL_AUTO=create` 거부 확인
- [x] 런타임 검증 script에서 `SPRING_JPA_HIBERNATE_DDL_AUTO=update` 거부 확인
- [ ] PR CI 통과
- [ ] main merge 후 `Deploy to Cloud Run` workflow가 `aim-be-prod`에 배포되는지 확인
- [ ] 배포 후 `aim-be-prod` 로그에서 `SchemaDropperImpl`, `SchemaCreatorImpl`, `drop table`, `create table`, `alter table`이 없는지 확인
- [ ] 배포 후 `MOCK_DB_20260526` 목업 데이터 유지 확인

---

## 🙏 요청

- 로컬에 `terraform`/`tofu`가 없어 Terraform fmt/validate는 실행하지 못했습니다.
- Docker daemon 기반 smoke test는 GitHub Actions에서 확인합니다.
- 현재 GitHub Actions Variables에 남아 있는 `GCP_REGION=asia-northeast3`, `CLOUD_RUN_SERVICE=aim-be`는 이 workflow에서 더 이상 운영 대상 결정에 사용하지 않습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Strengthened deployment environment validation with region and service constraints for production deployments.
  * Refined infrastructure configuration for Cloud Run and artifact registry region handling.
  * Enhanced runtime environment validation for deployment consistency.

* **Documentation**
  * Expanded CI/CD and deployment documentation with clearer configuration requirements.
  * Added troubleshooting guidance for deployment failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-industry-matching/aim-backend/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->