### PR TITLE
[Fix] #25 - Cloud Run 배포 시 FIREBASE_CREDENTIALS_JSON 환경변수 주입

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -28,6 +28,7 @@ env:
   DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
   DDL_AUTO: ${{ vars.DDL_AUTO || 'validate' }}
   FIREBASE_STORAGE_BUCKET: ${{ vars.FIREBASE_STORAGE_BUCKET || 'ajou-project-cafd9.firebasestorage.app' }}
+  FIREBASE_CREDENTIALS_JSON: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}
 
 jobs:
   deploy:
@@ -83,3 +84,4 @@ jobs:
             DB_PASSWORD=${{ env.DB_PASSWORD }}
             DDL_AUTO=${{ env.DDL_AUTO }}
             FIREBASE_STORAGE_BUCKET=${{ env.FIREBASE_STORAGE_BUCKET }}
+            FIREBASE_CREDENTIALS_JSON=${{ env.FIREBASE_CREDENTIALS_JSON }}


### PR DESCRIPTION
## 🔎 What is this PR?

- Cloud Run 배포 워크플로에 `FIREBASE_CREDENTIALS_JSON` 환경변수 주입이 누락되어 서버에서 Firebase Admin SDK가 올바른 서비스 계정으로 초기화되지 않는 문제를 수정합니다. closes #25

---

## 📝 Changes

- `.github/workflows/deploy-cloud-run.yml`
  - `env` 블록에 `FIREBASE_CREDENTIALS_JSON: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}` 추가
  - Cloud Run `env_vars`에 `FIREBASE_CREDENTIALS_JSON=${{ env.FIREBASE_CREDENTIALS_JSON }}` 추가

---

## 📚 Background / Context (선택)

- `FirebaseAdminConfig`는 `FIREBASE_CREDENTIALS_JSON` 환경변수를 읽어 Firebase Admin SDK를 초기화하도록 이미 구현되어 있음
- 해당 환경변수가 없으면 `getApplicationDefault()`로 폴백하여 엉뚱한 GCP 프로젝트 계정으로 초기화되고, 토큰의 `aud` 클레임 불일치로 `verifyIdToken` 실패 → 로그인 시 `{"message":"유효하지 않은 토큰입니다."}` 반환
- GitHub Secrets에 `FIREBASE_CREDENTIALS_JSON` 키로 Firebase 서비스 계정 키 JSON을 등록해야 정상 동작함

---

## ✔ Checklist

- [x] 코드는 로컬에서 정상적으로 빌드됩니다
- [x] 워크플로 문법 이상 없음
- [ ] GitHub Secrets에 `FIREBASE_CREDENTIALS_JSON` 등록 필요 (배포 전 선행 조건)

---

## 🙏 Request

- GitHub Secrets에 `FIREBASE_CREDENTIALS_JSON` 값이 등록되어 있는지 확인 부탁드립니다.
- 머지 후 배포 완료 시 로그인 요청이 정상 처리되는지 검증 부탁드립니다.